### PR TITLE
Include avr/pgmspace.h only when architecture is AVR

### DIFF
--- a/ST7032.cpp
+++ b/ST7032.cpp
@@ -29,7 +29,9 @@
 #include "ST7032.h"
 #include "Arduino.h"
 #include <Wire.h>
+#if defined(__AVR__)
 #include <avr/pgmspace.h>
+#endif
 
 // private methods
 


### PR DESCRIPTION
Thanks to @boochow https://blog.boochow.com/article/424685995.html
It works with ESP8266/ESP32 Arduino core.