### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,26 +12,26 @@ ST7032	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin               KEYWORD2
-setContrast         KEYWORD2
-setIcon             KEYWORD2
-clear               KEYWORD2
-home                KEYWORD2
-noDisplay           KEYWORD2
-display             KEYWORD2
-noBlink             KEYWORD2
-blink               KEYWORD2
-noCursor            KEYWORD2
-cursor              KEYWORD2
-scrollDisplayLeft   KEYWORD2
-scrollDisplayRight  KEYWORD2
-leftToRight         KEYWORD2
-rightToLeft         KEYWORD2
-autoscroll          KEYWORD2
-noAutoscroll        KEYWORD2
-createChar          KEYWORD2
-setCursor           KEYWORD2
-command             KEYWORD2
+begin	KEYWORD2
+setContrast	KEYWORD2
+setIcon	KEYWORD2
+clear	KEYWORD2
+home	KEYWORD2
+noDisplay	KEYWORD2
+display	KEYWORD2
+noBlink	KEYWORD2
+blink	KEYWORD2
+noCursor	KEYWORD2
+cursor	KEYWORD2
+scrollDisplayLeft	KEYWORD2
+scrollDisplayRight	KEYWORD2
+leftToRight	KEYWORD2
+rightToLeft	KEYWORD2
+autoscroll	KEYWORD2
+noAutoscroll	KEYWORD2
+createChar	KEYWORD2
+setCursor	KEYWORD2
+command	KEYWORD2
 
 ######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords